### PR TITLE
fix: update tox workflow to use src/betamax path

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,19 +13,19 @@ commands = py.test {posargs}
 basepython = python2.7
 deps =
     flake8
-commands = flake8 {posargs} betamax
+commands = flake8 {posargs} src/betamax
 
 [testenv:py37-flake8]
 basepython = python3.7
 deps =
     flake8
-commands = flake8 {posargs} betamax
+commands = flake8 {posargs} src/betamax
 
 [testenv:docstrings]
 deps =
     flake8
     flake8-docstrings
-commands = flake8 {posargs} betamax
+commands = flake8 {posargs} src/betamax
 
 [testenv:release]
 deps =


### PR DESCRIPTION
The betamax directory was moved into the src directory but the tox workflow was not updated to reflect this change. This commit updates the tox workflow to use the new path.

Refs: #203, cf6aefe